### PR TITLE
Add UserAgent on pixie requests.

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -77,6 +77,7 @@ func setUpConfig() error {
 		exporter: &exporter{
 			licenseKey: nrLicenseKey,
 			endpoint:   nrHostname,
+			userAgent:  "pixie/" + integrationVersion,
 		},
 		pixie: &pixie{
 			apiKey:    pixieAPIKey,
@@ -161,12 +162,14 @@ func (s *settings) BuildDate() string {
 type Exporter interface {
 	LicenseKey() string
 	Endpoint() string
+	UserAgent() string
 	validate() error
 }
 
 type exporter struct {
 	licenseKey string
 	endpoint   string
+	userAgent  string
 }
 
 func (e *exporter) validate() error {
@@ -182,6 +185,10 @@ func (e *exporter) LicenseKey() string {
 
 func (e *exporter) Endpoint() string {
 	return e.endpoint
+}
+
+func (e *exporter) UserAgent() string {
+	return e.userAgent
 }
 
 type Pixie interface {

--- a/internal/exporter/sender.go
+++ b/internal/exporter/sender.go
@@ -17,7 +17,7 @@ type Exporter interface {
 }
 
 func New(ctx context.Context, cfg config.Exporter) (Exporter, error) {
-	conn, outgoingCtx, err := createConnection(ctx, cfg.Endpoint(), cfg.LicenseKey())
+	conn, outgoingCtx, err := createConnection(ctx, cfg.Endpoint(), cfg.LicenseKey(), cfg.UserAgent())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/exporter/telemetry.go
+++ b/internal/exporter/telemetry.go
@@ -89,12 +89,14 @@ func (e *openTelemetry) SendSpans(spans []*tracepb.ResourceSpans) int {
 	return processed
 }
 
-func createConnection(ctx context.Context, endpoint string, apiKey string) (*grpc.ClientConn, context.Context, error) {
+func createConnection(ctx context.Context, endpoint string, apiKey string, userAgent string) (*grpc.ClientConn, context.Context, error) {
 	outgoingCtx := metadata.NewOutgoingContext(ctx, metadata.Pairs("api-key", apiKey))
-	var opts []grpc.DialOption
-	tlsDialOption := grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{}))
-	opts = append(opts, tlsDialOption)
-	conn, err := grpc.DialContext(outgoingCtx, endpoint, opts...)
+	conn, err := grpc.DialContext(
+		outgoingCtx,
+		endpoint,
+		grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{})),
+		grpc.WithUserAgent(userAgent),
+	)
 	if err != nil {
 		return nil, context.Background(), fmt.Errorf("error creating grpc connection: %w", err)
 	}


### PR DESCRIPTION
This PR adds user agent configuration to the pixie exporter for the purposes of tracking attribution of requests in the backend.

@fryckbos 