### PR TITLE
Add environment variables to limit the data sent to New Relic.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,19 @@ NR_LICENSE_KEY=
 The following environment variables are optional. 
 
 ```
+HTTP_SPAN_LIMIT=5000
+DB_SPAN_LIMIT=1000
+COLLECT_INTERVAL_SEC=10
+HTTP_SPAN_COLLECT_INTERVAL_SEC=10
+JVM_COLLECT_INTERVAL_SEC=10
+MYSQL_COLLECT_INTERVAL_SEC=10
+POSTGRES_COLLECT_INTERVAL_SEC=10
 PIXIE_ENDPOINT=work.withpixie.ai:443
 NR_OTLP_HOST=otlp.nr-data.net:4317
 VERBOSE=true
 ```
+
+The `*_LIMIT` and `*_INTERVAL_SEC` environment variables can be used to control the amount of data that is sent to New Relic. The `COLLECT_INTERVAL_SEC` environment variable sets the collection interval for all PXL scripts. The other `*_INTERVAL_SEC` environment variables are overrides for the individual scripts. Setting the interval to `0` will disable sending that data to New Relic. The smallest valid interval is 2 seconds.
 
 ## Testing
 

--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -20,31 +20,33 @@ var (
 type MetricsAdapter interface {
 	ID() string
 	Script() string
+	CollectIntervalSec() int64
 	Adapt(r *types.Record) ([]*metricpb.ResourceMetrics, error)
 }
 
 type SpansAdapter interface {
 	ID() string
 	Script() string
+	CollectIntervalSec() int64
 	Adapt(r *types.Record) ([]*tracepb.ResourceSpans, error)
 }
 
-func JVM(clusterName string) MetricsAdapter {
-	return &jvm{clusterName}
+func JVM(clusterName string, collectIntervalSec int64) MetricsAdapter {
+	return newJvm(clusterName, collectIntervalSec)
 }
 
-func HTTPMetrics(clusterName string) MetricsAdapter {
-	return &httpMetrics{clusterName}
+func HTTPMetrics(clusterName string, collectIntervalSec int64) MetricsAdapter {
+	return newHttpMetrics(clusterName, collectIntervalSec)
 }
 
-func HTTPSpans(clusterName string) SpansAdapter {
-	return &httpSpans{clusterName}
+func HTTPSpans(clusterName string, collectIntervalSec, spanLimit int64) SpansAdapter {
+	return newHttpSpans(clusterName, collectIntervalSec, spanLimit)
 }
 
-func MySQL(clusterName string) SpansAdapter {
-	return &mysql{clusterName}
+func MySQL(clusterName string, collectIntervalSec, spanLimit int64) SpansAdapter {
+	return newMysql(clusterName, collectIntervalSec, spanLimit)
 }
 
-func PgSQL(clusterName string) SpansAdapter {
-	return &pogsql{clusterName}
+func PgSQL(clusterName string, collectIntervalSec, spanLimit int64) SpansAdapter {
+	return newPogsql(clusterName, collectIntervalSec, spanLimit)
 }

--- a/internal/adapter/jvm.go
+++ b/internal/adapter/jvm.go
@@ -11,11 +11,11 @@ import (
 	"px.dev/pxapi/types"
 )
 
-const jvmPXL = `
-#px:set max_output_rows_per_table=15000
+const jvmTemplate = `
+#px:set max_output_rows_per_table=10000
 
 import px
-df = px.DataFrame('jvm_stats', start_time='-10s')
+df = px.DataFrame('jvm_stats', start_time='-%ds')
 
 df.container = df.ctx['container_name']
 df.pod = df.ctx['pod']
@@ -74,15 +74,25 @@ type metricDef struct {
 }
 
 type jvm struct {
-	clusterName string
+	clusterName        string
+	collectIntervalSec int64
+	script             string
+}
+
+func newJvm(clusterName string, collectIntervalSec int64) *jvm {
+	return &jvm{clusterName, collectIntervalSec, fmt.Sprintf(jvmTemplate, collectIntervalSec)}
 }
 
 func (a *jvm) ID() string {
 	return "jvm"
 }
 
+func (a *jvm) CollectIntervalSec() int64 {
+	return a.collectIntervalSec
+}
+
 func (a *jvm) Script() string {
-	return jvmPXL
+	return a.script
 }
 
 func (a *jvm) Adapt(r *types.Record) ([]*metricpb.ResourceMetrics, error) {

--- a/internal/adapter/mysql.go
+++ b/internal/adapter/mysql.go
@@ -1,6 +1,7 @@
 package adapter
 
 import (
+	"fmt"
 	"time"
 
 	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
@@ -8,11 +9,11 @@ import (
 	"px.dev/pxapi/types"
 )
 
-var mysqlPXL = `
-#px:set max_output_rows_per_table=15000
+const mysqlTemplate = `
+#px:set max_output_rows_per_table=%d
 
 import px
-df = px.DataFrame('mysql_events', start_time='-10s')
+df = px.DataFrame('mysql_events', start_time='-%ds')
 df.pod = df.ctx['pod']
 df.service = df.ctx['service']
 df.namespace = df.ctx['namespace']	
@@ -27,15 +28,25 @@ px.display(df, 'mysql')
 `
 
 type mysql struct {
-	clusterName string
+	clusterName        string
+	collectIntervalSec int64
+	script             string
+}
+
+func newMysql(clusterName string, collectIntervalSec, spanLimit int64) *mysql {
+	return &mysql{clusterName, collectIntervalSec, fmt.Sprintf(mysqlTemplate, spanLimit, collectIntervalSec)}
 }
 
 func (a *mysql) ID() string {
 	return "db_mysql"
 }
 
+func (a *mysql) CollectIntervalSec() int64 {
+	return a.collectIntervalSec
+}
+
 func (a *mysql) Script() string {
-	return mysqlPXL
+	return a.script
 }
 
 func (a *mysql) Adapt(r *types.Record) ([]*tracepb.ResourceSpans, error) {


### PR DESCRIPTION
Adding environment variables to control the collection intervals and the amount of spans sent to New Relic.