### PR TITLE
Decorate all telemetry with the Pixie cluster id

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -58,31 +58,31 @@ func main() {
 func runWorkers(ctx context.Context, cfg config.Worker, vz *pxapi.VizierClient, exporter exporter.Exporter, wg *sync.WaitGroup) {
 	w := worker.Build(ctx, cfg, vz, exporter)
 	if cfg.HttpSpanCollectInterval() > 1 {
-		httpSpans := adapter.HTTPSpans(cfg.ClusterName(), cfg.HttpSpanCollectInterval(), cfg.HttpSpanLimit())
+		httpSpans := adapter.HTTPSpans(cfg.ClusterName(), cfg.PixieClusterID(), cfg.HttpSpanCollectInterval(), cfg.HttpSpanLimit())
 		logWorkerStart(httpSpans.ID(), httpSpans.CollectIntervalSec(), cfg.HttpSpanLimit(), httpSpans.Script())
 		go w.Spans(httpSpans, wg)
 		wg.Add(1)
 	}
 	if cfg.MysqlCollectInterval() > 1 {
-		mysql := adapter.MySQL(cfg.ClusterName(), cfg.MysqlCollectInterval(), cfg.DbSpanLimit())
+		mysql := adapter.MySQL(cfg.ClusterName(), cfg.PixieClusterID(), cfg.MysqlCollectInterval(), cfg.DbSpanLimit())
 		logWorkerStart(mysql.ID(), mysql.CollectIntervalSec(), cfg.DbSpanLimit(), mysql.Script())
 		go w.Spans(mysql, wg)
 		wg.Add(1)
 	}
 	if cfg.PostgresCollectInterval() > 1 {
-		pgsql := adapter.PgSQL(cfg.ClusterName(), cfg.PostgresCollectInterval(), cfg.DbSpanLimit())
+		pgsql := adapter.PgSQL(cfg.ClusterName(), cfg.PixieClusterID(), cfg.PostgresCollectInterval(), cfg.DbSpanLimit())
 		logWorkerStart(pgsql.ID(), pgsql.CollectIntervalSec(), cfg.DbSpanLimit(), pgsql.Script())
 		go w.Spans(pgsql, wg)
 		wg.Add(1)
 	}
 	if cfg.HttpMetricCollectInterval() > 1 {
-		httpMetrics := adapter.HTTPMetrics(cfg.ClusterName(), cfg.HttpMetricCollectInterval())
+		httpMetrics := adapter.HTTPMetrics(cfg.ClusterName(), cfg.PixieClusterID(), cfg.HttpMetricCollectInterval())
 		logWorkerStart(httpMetrics.ID(), httpMetrics.CollectIntervalSec(), -1, httpMetrics.Script())
 		go w.Metrics(httpMetrics, wg)
 		wg.Add(1)
 	}
 	if cfg.JvmCollectInterval() > 1 {
-		jvm := adapter.JVM(cfg.ClusterName(), cfg.JvmCollectInterval())
+		jvm := adapter.JVM(cfg.ClusterName(), cfg.PixieClusterID(), cfg.JvmCollectInterval())
 		logWorkerStart(jvm.ID(), jvm.CollectIntervalSec(), -1, jvm.Script())
 		go w.Metrics(jvm, wg)
 		wg.Add(1)

--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -31,22 +31,22 @@ type SpansAdapter interface {
 	Adapt(r *types.Record) ([]*tracepb.ResourceSpans, error)
 }
 
-func JVM(clusterName, clusterID string, collectIntervalSec int64) MetricsAdapter {
-	return newJvm(clusterName, clusterID, collectIntervalSec)
+func JVM(clusterName, pixieClusterID string, collectIntervalSec int64) MetricsAdapter {
+	return newJvm(clusterName, pixieClusterID, collectIntervalSec)
 }
 
-func HTTPMetrics(clusterName, clusterID string, collectIntervalSec int64) MetricsAdapter {
-	return newHttpMetrics(clusterName, clusterID, collectIntervalSec)
+func HTTPMetrics(clusterName, pixieClusterID string, collectIntervalSec int64) MetricsAdapter {
+	return newHttpMetrics(clusterName, pixieClusterID, collectIntervalSec)
 }
 
-func HTTPSpans(clusterName, clusterID string, collectIntervalSec, spanLimit int64) SpansAdapter {
-	return newHttpSpans(clusterName, clusterID, collectIntervalSec, spanLimit)
+func HTTPSpans(clusterName, pixieClusterID string, collectIntervalSec, spanLimit int64) SpansAdapter {
+	return newHttpSpans(clusterName, pixieClusterID, collectIntervalSec, spanLimit)
 }
 
-func MySQL(clusterName, clusterID string, collectIntervalSec, spanLimit int64) SpansAdapter {
-	return newMysql(clusterName, clusterID, collectIntervalSec, spanLimit)
+func MySQL(clusterName, pixieClusterID string, collectIntervalSec, spanLimit int64) SpansAdapter {
+	return newMysql(clusterName, pixieClusterID, collectIntervalSec, spanLimit)
 }
 
-func PgSQL(clusterName, clusterID string, collectIntervalSec, spanLimit int64) SpansAdapter {
-	return newPogsql(clusterName, clusterID, collectIntervalSec, spanLimit)
+func PgSQL(clusterName, pixieClusterID string, collectIntervalSec, spanLimit int64) SpansAdapter {
+	return newPogsql(clusterName, pixieClusterID, collectIntervalSec, spanLimit)
 }

--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -31,22 +31,22 @@ type SpansAdapter interface {
 	Adapt(r *types.Record) ([]*tracepb.ResourceSpans, error)
 }
 
-func JVM(clusterName string, collectIntervalSec int64) MetricsAdapter {
-	return newJvm(clusterName, collectIntervalSec)
+func JVM(clusterName, clusterID string, collectIntervalSec int64) MetricsAdapter {
+	return newJvm(clusterName, clusterID, collectIntervalSec)
 }
 
-func HTTPMetrics(clusterName string, collectIntervalSec int64) MetricsAdapter {
-	return newHttpMetrics(clusterName, collectIntervalSec)
+func HTTPMetrics(clusterName, clusterID string, collectIntervalSec int64) MetricsAdapter {
+	return newHttpMetrics(clusterName, clusterID, collectIntervalSec)
 }
 
-func HTTPSpans(clusterName string, collectIntervalSec, spanLimit int64) SpansAdapter {
-	return newHttpSpans(clusterName, collectIntervalSec, spanLimit)
+func HTTPSpans(clusterName, clusterID string, collectIntervalSec, spanLimit int64) SpansAdapter {
+	return newHttpSpans(clusterName, clusterID, collectIntervalSec, spanLimit)
 }
 
-func MySQL(clusterName string, collectIntervalSec, spanLimit int64) SpansAdapter {
-	return newMysql(clusterName, collectIntervalSec, spanLimit)
+func MySQL(clusterName, clusterID string, collectIntervalSec, spanLimit int64) SpansAdapter {
+	return newMysql(clusterName, clusterID, collectIntervalSec, spanLimit)
 }
 
-func PgSQL(clusterName string, collectIntervalSec, spanLimit int64) SpansAdapter {
-	return newPogsql(clusterName, collectIntervalSec, spanLimit)
+func PgSQL(clusterName, clusterID string, collectIntervalSec, spanLimit int64) SpansAdapter {
+	return newPogsql(clusterName, clusterID, collectIntervalSec, spanLimit)
 }

--- a/internal/adapter/helper.go
+++ b/internal/adapter/helper.go
@@ -38,9 +38,13 @@ func takeNamespaceServiceAndPod(r *types.Record) (ns string, services []string, 
 	return
 }
 
-func creteResourceFunc(r *types.Record, namespace, pod, cluster string) func([]string) []resourcepb.Resource {
+func createResourceFunc(r *types.Record, namespace, pod, clusterName, clusterId string) func([]string) []resourcepb.Resource {
 	resource := resourcepb.Resource{
 		Attributes: []*commonpb.KeyValue{
+			{
+				Key:   "k8s.cluster.id",
+				Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: clusterId}},
+			},
 			{
 				Key:   "instrumentation.provider",
 				Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: instrumentationName}},
@@ -64,7 +68,7 @@ func creteResourceFunc(r *types.Record, namespace, pod, cluster string) func([]s
 			},
 			{
 				Key:   "k8s.cluster.name",
-				Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: cluster}},
+				Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: clusterName}},
 			},
 		},
 	}
@@ -81,9 +85,9 @@ func creteResourceFunc(r *types.Record, namespace, pod, cluster string) func([]s
 	}
 }
 
-func createResources(r *types.Record, cluster string) []resourcepb.Resource {
+func createResources(r *types.Record, clusterName, clusterId string) []resourcepb.Resource {
 	namespace, services, pod := takeNamespaceServiceAndPod(r)
-	return creteResourceFunc(r, namespace, pod, cluster)(services)
+	return createResourceFunc(r, namespace, pod, clusterName, clusterId)(services)
 }
 
 func createArrayOfSpans(resources []resourcepb.Resource, il []*tracepb.InstrumentationLibrarySpans) []*tracepb.ResourceSpans {

--- a/internal/adapter/helper.go
+++ b/internal/adapter/helper.go
@@ -42,7 +42,7 @@ func createResourceFunc(r *types.Record, namespace, pod, clusterName, pixieClust
 	resource := resourcepb.Resource{
 		Attributes: []*commonpb.KeyValue{
 			{
-				Key:   "k8s.cluster.id",
+				Key:   "pixie.cluster.id",
 				Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: pixieClusterID}},
 			},
 			{

--- a/internal/adapter/helper.go
+++ b/internal/adapter/helper.go
@@ -38,12 +38,12 @@ func takeNamespaceServiceAndPod(r *types.Record) (ns string, services []string, 
 	return
 }
 
-func createResourceFunc(r *types.Record, namespace, pod, clusterName, clusterId string) func([]string) []resourcepb.Resource {
+func createResourceFunc(r *types.Record, namespace, pod, clusterName, pixieClusterID string) func([]string) []resourcepb.Resource {
 	resource := resourcepb.Resource{
 		Attributes: []*commonpb.KeyValue{
 			{
 				Key:   "k8s.cluster.id",
-				Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: clusterId}},
+				Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: pixieClusterID}},
 			},
 			{
 				Key:   "instrumentation.provider",
@@ -85,9 +85,9 @@ func createResourceFunc(r *types.Record, namespace, pod, clusterName, clusterId 
 	}
 }
 
-func createResources(r *types.Record, clusterName, clusterId string) []resourcepb.Resource {
+func createResources(r *types.Record, clusterName, pixieClusterID string) []resourcepb.Resource {
 	namespace, services, pod := takeNamespaceServiceAndPod(r)
-	return createResourceFunc(r, namespace, pod, clusterName, clusterId)(services)
+	return createResourceFunc(r, namespace, pod, clusterName, pixieClusterID)(services)
 }
 
 func createArrayOfSpans(resources []resourcepb.Resource, il []*tracepb.InstrumentationLibrarySpans) []*tracepb.ResourceSpans {

--- a/internal/adapter/http_metric.go
+++ b/internal/adapter/http_metric.go
@@ -36,13 +36,13 @@ px.display(df, 'http')
 
 type httpMetrics struct {
 	clusterName        string
-	clusterId          string
+	pixieClusterID     string
 	collectIntervalSec int64
 	script             string
 }
 
-func newHttpMetrics(clusterName string, clusterId string, collectIntervalSec int64) *httpMetrics {
-	return &httpMetrics{clusterName, clusterId, collectIntervalSec, fmt.Sprintf(httpMetricsTemplate, collectIntervalSec)}
+func newHttpMetrics(clusterName string, pixieClusterID string, collectIntervalSec int64) *httpMetrics {
+	return &httpMetrics{clusterName, pixieClusterID, collectIntervalSec, fmt.Sprintf(httpMetricsTemplate, collectIntervalSec)}
 }
 
 func (a *httpMetrics) ID() string {
@@ -65,7 +65,7 @@ func (a *httpMetrics) Adapt(r *types.Record) ([]*metricpb.ResourceMetrics, error
 	latSum := float64(r.GetDatum("latency_sum").(*types.Int64Value).Value()) / 1000000
 	latCount := float64(r.GetDatum("latency_count").(*types.Int64Value).Value())
 
-	resources := createResources(r, a.clusterName, a.clusterId)
+	resources := createResources(r, a.clusterName, a.pixieClusterID)
 
 	return createArrayOfMetrics(resources, []*metricpb.InstrumentationLibraryMetrics{
 		{

--- a/internal/adapter/http_metric.go
+++ b/internal/adapter/http_metric.go
@@ -36,12 +36,13 @@ px.display(df, 'http')
 
 type httpMetrics struct {
 	clusterName        string
+	clusterId          string
 	collectIntervalSec int64
 	script             string
 }
 
-func newHttpMetrics(clusterName string, collectIntervalSec int64) *httpMetrics {
-	return &httpMetrics{clusterName, collectIntervalSec,fmt.Sprintf(httpMetricsTemplate, collectIntervalSec)}
+func newHttpMetrics(clusterName string, clusterId string, collectIntervalSec int64) *httpMetrics {
+	return &httpMetrics{clusterName, clusterId, collectIntervalSec, fmt.Sprintf(httpMetricsTemplate, collectIntervalSec)}
 }
 
 func (a *httpMetrics) ID() string {
@@ -64,7 +65,7 @@ func (a *httpMetrics) Adapt(r *types.Record) ([]*metricpb.ResourceMetrics, error
 	latSum := float64(r.GetDatum("latency_sum").(*types.Int64Value).Value()) / 1000000
 	latCount := float64(r.GetDatum("latency_count").(*types.Int64Value).Value())
 
-	resources := createResources(r, a.clusterName)
+	resources := createResources(r, a.clusterName, a.clusterId)
 
 	return createArrayOfMetrics(resources, []*metricpb.InstrumentationLibraryMetrics{
 		{

--- a/internal/adapter/http_span.go
+++ b/internal/adapter/http_span.go
@@ -40,12 +40,13 @@ px.display(df, 'http')
 
 type httpSpans struct {
 	clusterName        string
+	clusterID          string
 	collectIntervalSec int64
 	script             string
 }
 
-func newHttpSpans(clusterName string, collectIntervalSec int64, spanLimit int64) *httpSpans {
-	return &httpSpans{clusterName, collectIntervalSec, fmt.Sprintf(spanTemplate, spanLimit, collectIntervalSec)}
+func newHttpSpans(clusterName, clusterID string, collectIntervalSec int64, spanLimit int64) *httpSpans {
+	return &httpSpans{clusterName, clusterID, collectIntervalSec, fmt.Sprintf(spanTemplate, spanLimit, collectIntervalSec)}
 }
 
 func (a *httpSpans) ID() string {
@@ -93,7 +94,7 @@ func (a *httpSpans) Adapt(r *types.Record) ([]*tracepb.ResourceSpans, error) {
 	method := r.GetDatum("req_method").String()
 	statusCode := r.GetDatum("resp_status").(*types.Int64Value).Value()
 	userAgent := r.GetDatum("user_agent").String()
-	resources := createResources(r, a.clusterName)
+	resources := createResources(r, a.clusterName, a.clusterID)
 	output := make([]*tracepb.ResourceSpans, 0)
 
 	for i := range parentServices {

--- a/internal/adapter/http_span.go
+++ b/internal/adapter/http_span.go
@@ -40,13 +40,13 @@ px.display(df, 'http')
 
 type httpSpans struct {
 	clusterName        string
-	clusterID          string
+	pixieClusterID     string
 	collectIntervalSec int64
 	script             string
 }
 
-func newHttpSpans(clusterName, clusterID string, collectIntervalSec int64, spanLimit int64) *httpSpans {
-	return &httpSpans{clusterName, clusterID, collectIntervalSec, fmt.Sprintf(spanTemplate, spanLimit, collectIntervalSec)}
+func newHttpSpans(clusterName, pixieClusterID string, collectIntervalSec int64, spanLimit int64) *httpSpans {
+	return &httpSpans{clusterName, pixieClusterID, collectIntervalSec, fmt.Sprintf(spanTemplate, spanLimit, collectIntervalSec)}
 }
 
 func (a *httpSpans) ID() string {
@@ -94,7 +94,7 @@ func (a *httpSpans) Adapt(r *types.Record) ([]*tracepb.ResourceSpans, error) {
 	method := r.GetDatum("req_method").String()
 	statusCode := r.GetDatum("resp_status").(*types.Int64Value).Value()
 	userAgent := r.GetDatum("user_agent").String()
-	resources := createResources(r, a.clusterName, a.clusterID)
+	resources := createResources(r, a.clusterName, a.pixieClusterID)
 	output := make([]*tracepb.ResourceSpans, 0)
 
 	for i := range parentServices {

--- a/internal/adapter/jvm.go
+++ b/internal/adapter/jvm.go
@@ -75,13 +75,13 @@ type metricDef struct {
 
 type jvm struct {
 	clusterName        string
-	clusterID        string
+	pixieClusterID     string
 	collectIntervalSec int64
 	script             string
 }
 
-func newJvm(clusterName, clusterID string, collectIntervalSec int64) *jvm {
-	return &jvm{clusterName, clusterID, collectIntervalSec, fmt.Sprintf(jvmTemplate, collectIntervalSec)}
+func newJvm(clusterName, pixieClusterID string, collectIntervalSec int64) *jvm {
+	return &jvm{clusterName, pixieClusterID, collectIntervalSec, fmt.Sprintf(jvmTemplate, collectIntervalSec)}
 }
 
 func (a *jvm) ID() string {
@@ -99,7 +99,7 @@ func (a *jvm) Script() string {
 func (a *jvm) Adapt(r *types.Record) ([]*metricpb.ResourceMetrics, error) {
 	timestamp := r.GetDatum("time_").(*types.Time64NSValue).Value()
 	instrumentationLibraries := make([]*metricpb.InstrumentationLibraryMetrics, len(metricMapping))
-	resources := createResources(r, a.clusterName, a.clusterID)
+	resources := createResources(r, a.clusterName, a.pixieClusterID)
 	index := 0
 	for metricName, def := range metricMapping {
 		value, err := getValueFromJVMMetric(r, metricName)

--- a/internal/adapter/jvm.go
+++ b/internal/adapter/jvm.go
@@ -75,12 +75,13 @@ type metricDef struct {
 
 type jvm struct {
 	clusterName        string
+	clusterID        string
 	collectIntervalSec int64
 	script             string
 }
 
-func newJvm(clusterName string, collectIntervalSec int64) *jvm {
-	return &jvm{clusterName, collectIntervalSec, fmt.Sprintf(jvmTemplate, collectIntervalSec)}
+func newJvm(clusterName, clusterID string, collectIntervalSec int64) *jvm {
+	return &jvm{clusterName, clusterID, collectIntervalSec, fmt.Sprintf(jvmTemplate, collectIntervalSec)}
 }
 
 func (a *jvm) ID() string {
@@ -98,7 +99,7 @@ func (a *jvm) Script() string {
 func (a *jvm) Adapt(r *types.Record) ([]*metricpb.ResourceMetrics, error) {
 	timestamp := r.GetDatum("time_").(*types.Time64NSValue).Value()
 	instrumentationLibraries := make([]*metricpb.InstrumentationLibraryMetrics, len(metricMapping))
-	resources := createResources(r, a.clusterName)
+	resources := createResources(r, a.clusterName, a.clusterID)
 	index := 0
 	for metricName, def := range metricMapping {
 		value, err := getValueFromJVMMetric(r, metricName)

--- a/internal/adapter/mysql.go
+++ b/internal/adapter/mysql.go
@@ -29,13 +29,13 @@ px.display(df, 'mysql')
 
 type mysql struct {
 	clusterName        string
-	clusterID          string
+	pixieClusterID     string
 	collectIntervalSec int64
 	script             string
 }
 
-func newMysql(clusterName, clusterID string, collectIntervalSec, spanLimit int64) *mysql {
-	return &mysql{clusterName, clusterID, collectIntervalSec, fmt.Sprintf(mysqlTemplate, spanLimit, collectIntervalSec)}
+func newMysql(clusterName, pixieClusterID string, collectIntervalSec, spanLimit int64) *mysql {
+	return &mysql{clusterName, pixieClusterID, collectIntervalSec, fmt.Sprintf(mysqlTemplate, spanLimit, collectIntervalSec)}
 }
 
 func (a *mysql) ID() string {
@@ -55,7 +55,7 @@ func (a *mysql) Adapt(r *types.Record) ([]*tracepb.ResourceSpans, error) {
 	traceID := idGenerator.NewTraceID()
 	timestamp := r.GetDatum("time_").(*types.Time64NSValue).Value()
 	duration := time.Duration(r.GetDatum("latency").(*types.Int64Value).Value())
-	resources := createResources(r, a.clusterName, a.clusterID)
+	resources := createResources(r, a.clusterName, a.pixieClusterID)
 	return createArrayOfSpans(resources, []*tracepb.InstrumentationLibrarySpans{
 		{
 			InstrumentationLibrary: instrumentationLibrary,

--- a/internal/adapter/mysql.go
+++ b/internal/adapter/mysql.go
@@ -29,12 +29,13 @@ px.display(df, 'mysql')
 
 type mysql struct {
 	clusterName        string
+	clusterID          string
 	collectIntervalSec int64
 	script             string
 }
 
-func newMysql(clusterName string, collectIntervalSec, spanLimit int64) *mysql {
-	return &mysql{clusterName, collectIntervalSec, fmt.Sprintf(mysqlTemplate, spanLimit, collectIntervalSec)}
+func newMysql(clusterName, clusterID string, collectIntervalSec, spanLimit int64) *mysql {
+	return &mysql{clusterName, clusterID, collectIntervalSec, fmt.Sprintf(mysqlTemplate, spanLimit, collectIntervalSec)}
 }
 
 func (a *mysql) ID() string {
@@ -54,7 +55,7 @@ func (a *mysql) Adapt(r *types.Record) ([]*tracepb.ResourceSpans, error) {
 	traceID := idGenerator.NewTraceID()
 	timestamp := r.GetDatum("time_").(*types.Time64NSValue).Value()
 	duration := time.Duration(r.GetDatum("latency").(*types.Int64Value).Value())
-	resources := createResources(r, a.clusterName)
+	resources := createResources(r, a.clusterName, a.clusterID)
 	return createArrayOfSpans(resources, []*tracepb.InstrumentationLibrarySpans{
 		{
 			InstrumentationLibrary: instrumentationLibrary,

--- a/internal/adapter/postgres.go
+++ b/internal/adapter/postgres.go
@@ -29,12 +29,13 @@ px.display(df, 'pgsql')
 
 type pogsql struct {
 	clusterName        string
+	clusterID          string
 	collectIntervalSec int64
 	script             string
 }
 
-func newPogsql(clusterName string, collectIntervalSec, spanLimit int64) *pogsql {
-	return &pogsql{clusterName, collectIntervalSec, fmt.Sprintf(pgsqlTemplate, spanLimit, collectIntervalSec)}
+func newPogsql(clusterName, clusterID string, collectIntervalSec, spanLimit int64) *pogsql {
+	return &pogsql{clusterName, clusterID, collectIntervalSec, fmt.Sprintf(pgsqlTemplate, spanLimit, collectIntervalSec)}
 }
 
 func (a *pogsql) ID() string {
@@ -54,7 +55,7 @@ func (a *pogsql) Adapt(r *types.Record) ([]*tracepb.ResourceSpans, error) {
 	traceID := idGenerator.NewTraceID()
 	timestamp := r.GetDatum("time_").(*types.Time64NSValue).Value()
 	duration := time.Duration(r.GetDatum("latency").(*types.Int64Value).Value())
-	resources := createResources(r, a.clusterName)
+	resources := createResources(r, a.clusterName, a.clusterID)
 	return createArrayOfSpans(resources, []*tracepb.InstrumentationLibrarySpans{
 		{
 			InstrumentationLibrary: instrumentationLibrary,

--- a/internal/adapter/postgres.go
+++ b/internal/adapter/postgres.go
@@ -29,13 +29,13 @@ px.display(df, 'pgsql')
 
 type pogsql struct {
 	clusterName        string
-	clusterID          string
+	pixieClusterID     string
 	collectIntervalSec int64
 	script             string
 }
 
-func newPogsql(clusterName, clusterID string, collectIntervalSec, spanLimit int64) *pogsql {
-	return &pogsql{clusterName, clusterID, collectIntervalSec, fmt.Sprintf(pgsqlTemplate, spanLimit, collectIntervalSec)}
+func newPogsql(clusterName, pixieClusterID string, collectIntervalSec, spanLimit int64) *pogsql {
+	return &pogsql{clusterName, pixieClusterID, collectIntervalSec, fmt.Sprintf(pgsqlTemplate, spanLimit, collectIntervalSec)}
 }
 
 func (a *pogsql) ID() string {
@@ -55,7 +55,7 @@ func (a *pogsql) Adapt(r *types.Record) ([]*tracepb.ResourceSpans, error) {
 	traceID := idGenerator.NewTraceID()
 	timestamp := r.GetDatum("time_").(*types.Time64NSValue).Value()
 	duration := time.Duration(r.GetDatum("latency").(*types.Int64Value).Value())
-	resources := createResources(r, a.clusterName, a.clusterID)
+	resources := createResources(r, a.clusterName, a.pixieClusterID)
 	return createArrayOfSpans(resources, []*tracepb.InstrumentationLibrarySpans{
 		{
 			InstrumentationLibrary: instrumentationLibrary,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,8 +41,8 @@ var (
 	integrationVersion = "0.0.0"
 	gitCommit          = ""
 	buildDate          = ""
-	once     sync.Once
-	instance Config
+	once               sync.Once
+	instance           Config
 )
 
 func GetConfig() (Config, error) {
@@ -110,14 +110,15 @@ func setUpConfig() error {
 			version:   integrationVersion,
 		},
 		worker: &worker{
-			clusterName: clusterName,
-			httpSpanLimit: httpSpanLimit,
-			dbSpanLimit: dbSpanLimit,
+			clusterName:               clusterName,
+			pixieClusterID:            pixieClusterID,
+			httpSpanLimit:             httpSpanLimit,
+			dbSpanLimit:               dbSpanLimit,
 			httpMetricCollectInterval: httpMetricCollectInterval,
-			httpSpanCollectInterval: httpSpanCollectInterval,
-			jvmCollectInterval: jvmCollectInterval,
-			mysqlCollectInterval: mysqlCollectInterval,
-			postgresCollectInterval: postgresCollectInterval,
+			httpSpanCollectInterval:   httpSpanCollectInterval,
+			jvmCollectInterval:        jvmCollectInterval,
+			mysqlCollectInterval:      mysqlCollectInterval,
+			postgresCollectInterval:   postgresCollectInterval,
 		},
 		exporter: &exporter{
 			licenseKey: nrLicenseKey,
@@ -293,6 +294,7 @@ func (p *pixie) Host() string {
 
 type Worker interface {
 	ClusterName() string
+	PixieClusterID() string
 	HttpSpanLimit() int64
 	DbSpanLimit() int64
 	HttpMetricCollectInterval() int64
@@ -304,14 +306,15 @@ type Worker interface {
 }
 
 type worker struct {
-	clusterName string
-	httpSpanLimit int64
-	dbSpanLimit int64
+	clusterName               string
+	pixieClusterID            string
+	httpSpanLimit             int64
+	dbSpanLimit               int64
 	httpMetricCollectInterval int64
-	httpSpanCollectInterval int64
-	jvmCollectInterval int64
-	mysqlCollectInterval int64
-	postgresCollectInterval int64
+	httpSpanCollectInterval   int64
+	jvmCollectInterval        int64
+	mysqlCollectInterval      int64
+	postgresCollectInterval   int64
 }
 
 func (a *worker) validate() error {
@@ -323,6 +326,10 @@ func (a *worker) validate() error {
 
 func (a *worker) ClusterName() string {
 	return a.clusterName
+}
+
+func (a *worker) PixieClusterID() string {
+	return a.pixieClusterID
 }
 
 func (a *worker) HttpSpanLimit() int64 {


### PR DESCRIPTION
This decorates all the metrics sent by the integration with the Pixie cluster ID, so that issues with cluster name disambiguation in Pixie can be avoided.

**More details**

The cluster ID is a random UUID assigned as identifier of the cluster. It can be used in scenario where two different clusters get assigned the same cluster name by users. In this case, Pixie "disambiguates" the names by appending a few random bytes to one of them (for instance, if two clusters are named `douglas-cluster` Pixie would rename one of them to something like `douglas-cluster_abc123`). To be sure about which cluster is which, one has to check their IDs in the UI and compare to what they see in the cluster (via the Pixie CLI or inspecting in-cluster secrets/configmaps).