### PR TITLE
Trace database request on the client side only.

### DIFF
--- a/internal/adapter/mysql.go
+++ b/internal/adapter/mysql.go
@@ -22,6 +22,7 @@ df.container = df.ctx['container_name']
 df.normed_query_struct = px.normalize_mysql(df.req_body, df.req_cmd)
 df.query = px.pluck(df.normed_query_struct, 'query')
 df = df[df.query != ""]
+df = df[df.trace_role == 1]
 
 df = df[['time_', 'container', 'service', 'pod', 'namespace', 'query', 'latency']]
 px.display(df, 'mysql')

--- a/internal/adapter/postgres.go
+++ b/internal/adapter/postgres.go
@@ -22,6 +22,7 @@ df.container = df.ctx['container_name']
 df.normed_query_struct = px.normalize_pgsql(df.req, df.req_cmd)
 df.query = px.pluck(df.normed_query_struct, 'query')
 df = df[df.query != ""]
+df = df[df.trace_role == 1]
 
 df = df[['time_', 'container', 'service', 'pod', 'namespace', 'query', 'latency']]
 px.display(df, 'pgsql')


### PR DESCRIPTION
Trace database requests on the client side only. Otherwise this results in showing the database as an OpenTelemetry service with no data, expect for database requests.