### PR TITLE
Update Pixie SDK to v0.2.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	google.golang.org/genproto v0.0.0-20210405174219-a39eb2f71cb9 // indirect
 	google.golang.org/grpc v1.41.0
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
-	px.dev/pxapi v0.2.0
+	px.dev/pxapi v0.2.1
 )
 
 go 1.16

--- a/go.sum
+++ b/go.sum
@@ -265,3 +265,5 @@ honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 px.dev/pxapi v0.2.0 h1:jT530z1ecA/WUFWGqmLEmZBiao9RaMzqgv/8Lfa/MpQ=
 px.dev/pxapi v0.2.0/go.mod h1:I6MU0yzBHBXTR5nGE24JfnFlAv1hQDHR3oqWm02vEnw=
+px.dev/pxapi v0.2.1 h1:GSFIsW+fjHFP3V3c5TcildiRy8iiNEOitv4ChcclxxM=
+px.dev/pxapi v0.2.1/go.mod h1:I6MU0yzBHBXTR5nGE24JfnFlAv1hQDHR3oqWm02vEnw=


### PR DESCRIPTION
The end-to-end encryption is causing high cpu usage. This problem is fixed in v0.2.1 of the Pixie SDK.