### PR TITLE
Move labels to attributes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ LABEL com.newrelic.image.version=$image_version \
 RUN apk --no-cache upgrade
 
 RUN apk add --no-cache --upgrade \
-    ca-certificates=20191127-r5 \
+    ca-certificates=20211220-r0 \
     && mkdir /lib64 \
     && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2 \
     && apk add --no-cache tini=0.19.0-r0

--- a/internal/adapter/http_metric.go
+++ b/internal/adapter/http_metric.go
@@ -2,7 +2,6 @@ package adapter
 
 import (
 	"fmt"
-	"strconv"
 	"time"
 
 	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
@@ -79,10 +78,12 @@ func (a *httpMetrics) Adapt(rh *ResourceHelper, r *types.Record) ([]*metricpb.Re
 						Summary: &metricpb.Summary{
 							DataPoints: []*metricpb.SummaryDataPoint{
 								{
-									Labels: []*commonpb.StringKeyValue{
+									Attributes: []*commonpb.KeyValue{
 										{
 											Key:   "http.status_code",
-											Value: strconv.Itoa(int(statusCode)),
+											Value: &commonpb.AnyValue{
+												Value: &commonpb.AnyValue_IntValue{statusCode},
+											},
 										},
 									},
 									StartTimeUnixNano: uint64(timestamp.UnixNano()),

--- a/internal/adapter/jvm.go
+++ b/internal/adapter/jvm.go
@@ -119,7 +119,7 @@ func (a *jvm) Adapt(rh *ResourceHelper, r *types.Record) ([]*metricpb.ResourceMe
 								{
 									TimeUnixNano: uint64(timestamp.UnixNano()),
 									Value:        &metricpb.NumberDataPoint_AsDouble{value},
-									Labels:       transformAttributes(def.attributes),
+									Attributes:       transformAttributes(def.attributes),
 								},
 							},
 						},
@@ -145,13 +145,15 @@ func getValueFromJVMMetric(r *types.Record, metricName string) (float64, error) 
 	return value, nil
 }
 
-func transformAttributes(attrs map[string]interface{}) []*commonpb.StringKeyValue {
-	stringKeyValues := make([]*commonpb.StringKeyValue, 0)
+func transformAttributes(attrs map[string]interface{}) []*commonpb.KeyValue {
+	keyValues := make([]*commonpb.KeyValue, 0)
 	for k := range attrs {
-		stringKeyValues = append(stringKeyValues, &commonpb.StringKeyValue{
-			Key:   k,
-			Value: fmt.Sprintf("%v", attrs[k]),
+		keyValues = append(keyValues, &commonpb.KeyValue{
+			Key: k,
+			Value: &commonpb.AnyValue{
+				Value: &commonpb.AnyValue_StringValue{fmt.Sprintf("%v", attrs[k])},
+			},
 		})
 	}
-	return stringKeyValues
+	return keyValues
 }


### PR DESCRIPTION
Labels have been deprecated and even removed in the latest release of the OTLP proto. Use Attributes instead for compatibility with New Relic's backend.