### PR TITLE
Rename instrumentation provider

### DIFF
--- a/internal/script/script.go
+++ b/internal/script/script.go
@@ -126,7 +126,8 @@ func getInterval(definition *ScriptDefinition, config ScriptConfig) int64 {
 }
 
 func templateScript(definition *ScriptDefinition, config ScriptConfig) string {
-	withClusterName := strings.Replace(definition.Script, "px.vizier_name()", "'"+config.ClusterName+"'", -1)
+	withIntegrationProvider := strings.Replace(definition.Script, "df.pixie = 'pixie'", "df.pixie = 'nr-pixie-integration'", -1)
+	withClusterName := strings.Replace(withIntegrationProvider, "px.vizier_name()", "'"+config.ClusterName+"'", -1)
 	lines := strings.Split(withClusterName, "\n")
 	exportLineNumber := 0
 	for i, line := range lines {

--- a/internal/script/script_test.go
+++ b/internal/script/script_test.go
@@ -27,7 +27,7 @@ df.latency_min = df.latency_min / 1000000
 
 df.cluster_name = %s
 df.cluster_id = px.vizier_id()
-df.pixie = 'pixie'
+df.pixie = 'nr-pixie-integration'
 `
 	testScriptTail = `
 px.export(


### PR DESCRIPTION
We want to distinguish between OTel data sent from the Pixie provider vs OTel data sent from the newrelic-pixie integration. This updates the scripts to use a different provider name.

Signed-off-by: Michelle Nguyen <michellenguyen@pixielabs.ai>