### PR TITLE
Update ca-certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ LABEL com.newrelic.image.version=$image_version \
 RUN apk --no-cache upgrade
 
 RUN apk add --no-cache --upgrade \
-    ca-certificates=20211220-r0 \
+    ca-certificates=20220614-r0 \
     && mkdir /lib64 \
     && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2 \
     && apk add --no-cache tini=0.19.0-r0


### PR DESCRIPTION
The current version no longer exists. Updating the ca-certificates version appears to work.
Signed-off-by: Michelle Nguyen <michellenguyen@pixielabs.ai>