### PR TITLE
Reformat script names

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,9 +172,9 @@ If the above requirements do not hold for your script, setting `addExcludes` to 
 
 ## Script registration behaviour
 
-The integration will consider scripts that start with `nri-` as managed by the integration. Scripts are registered per cluster and follow the `nri-<script name>-<cluster name>` pattern. The integration updates the scripts to bring them in-sync with the provided configuration. Scripts that are no longer present in the configuration are deleted. If you already have scripts that start with `nri-`, the integration will remove these if they are not specified in the integration configuration. 
+The integration will consider scripts that start with `nri-` as managed by the integration. Scripts are registered per cluster and follow the `nri-<script name> (<cluster name>)` pattern. The integration updates the scripts to bring them in-sync with the provided configuration. Scripts that are no longer present in the configuration are deleted. If you already have scripts that start with `nri-`, the integration will remove these if they are not specified in the integration configuration. 
 
-A cluster name can only be used for a single cluster. Scripts that follow the `nri-<script name>-<cluster name>` pattern with the same `<cluster-name>` but that were registered from another cluster will be overwritten or deleted.
+A cluster name can only be used for a single cluster. Scripts that follow the `nri-<script name> (<cluster name>)` pattern with the same `<cluster-name>` but that were registered from another cluster will be overwritten or deleted.
 
 ## Support
 

--- a/internal/pixie/pixie_test.go
+++ b/internal/pixie/pixie_test.go
@@ -23,7 +23,7 @@ func TestGetScriptClusterIdsAsString(t *testing.T) {
 
 func TestIsScriptForClusterById(t *testing.T) {
 	assert.False(t, isScriptForClusterById("something-else", []*uuidpb.UUID{}, "b8749d5b-3352-4a0c-92ef-4a1479464b74"))
-	assert.False(t, isScriptForClusterById("nri-script-cluster", []*uuidpb.UUID{}, "b8749d5b-3352-4a0c-92ef-4a1479464b74"))
-	assert.True(t, isScriptForClusterById("nri-script-cluster", []*uuidpb.UUID{utils.ProtoFromUUIDStrOrNil("b8749d5b-3352-4a0c-92ef-4a1479464b74")}, "b8749d5b-3352-4a0c-92ef-4a1479464b74"))
-	assert.False(t, isScriptForClusterById("nri-script-cluster", []*uuidpb.UUID{utils.ProtoFromUUIDStrOrNil("b8749d5b-3352-4a0c-92ef-4a1479464b74"), utils.ProtoFromUUIDStrOrNil("94fb8941-d353-43e0-b3e1-248f941c3af6")}, "b8749d5b-3352-4a0c-92ef-4a1479464b74"))
+	assert.False(t, isScriptForClusterById("nri-script (cluster)", []*uuidpb.UUID{}, "b8749d5b-3352-4a0c-92ef-4a1479464b74"))
+	assert.True(t, isScriptForClusterById("nri-script (cluster)", []*uuidpb.UUID{utils.ProtoFromUUIDStrOrNil("b8749d5b-3352-4a0c-92ef-4a1479464b74")}, "b8749d5b-3352-4a0c-92ef-4a1479464b74"))
+	assert.False(t, isScriptForClusterById("nri-script (cluster)", []*uuidpb.UUID{utils.ProtoFromUUIDStrOrNil("b8749d5b-3352-4a0c-92ef-4a1479464b74"), utils.ProtoFromUUIDStrOrNil("94fb8941-d353-43e0-b3e1-248f941c3af6")}, "b8749d5b-3352-4a0c-92ef-4a1479464b74"))
 }

--- a/internal/script/script.go
+++ b/internal/script/script.go
@@ -9,10 +9,15 @@ import (
 const (
 	scriptPrefix          = "nri-"
 	httpMetricsScript     = "HTTP Metrics"
-	httpSpansScript       = "HTTP Spans"
+	httpSampledSpansScript       = "HTTP Sampled Spans"
 	jvmMetricsScript      = "JVM Metrics"
+	mysqlSampledSpansScript      = "MySQL Sampled Spans"
+	postgresqlSampledSpansScript = "PostgreSQL Sampled Spans"
+	// TODO: These scripts are being renamed for more clarity. Remove the old script names once the new 
+	// plugin version has been released.
 	mysqlSpansScript      = "MySQL Spans"
 	postgresqlSpansScript = "PostgreSQL Spans"
+	httpSpansScript       = "HTTP Spans"
 )
 
 type ScriptConfig struct {
@@ -56,7 +61,7 @@ func IsNewRelicScript(scriptName string) bool {
 }
 
 func IsScriptForCluster(scriptName, clusterName string) bool {
-	return IsNewRelicScript(scriptName) && strings.HasSuffix(scriptName, "-"+clusterName)
+	return IsNewRelicScript(scriptName) && strings.HasSuffix(scriptName, fmt.Sprintf(" (%s)", clusterName))
 }
 
 func GetActions(scriptDefinitions []*ScriptDefinition, currentScripts []*Script, config ScriptConfig) ScriptActions {
@@ -98,7 +103,7 @@ func GetActions(scriptDefinitions []*ScriptDefinition, currentScripts []*Script,
 }
 
 func getScriptName(scriptName string, clusterName string) string {
-	return fmt.Sprintf("%s%s-%s", scriptPrefix, scriptName, clusterName)
+	return fmt.Sprintf("%s%s (%s)", scriptPrefix, scriptName, clusterName)
 }
 
 func getInterval(definition *ScriptDefinition, config ScriptConfig) int64 {
@@ -106,13 +111,13 @@ func getInterval(definition *ScriptDefinition, config ScriptConfig) int64 {
 		var interval int64
 		if definition.Name == httpMetricsScript {
 			interval = config.HttpMetricCollectInterval
-		} else if definition.Name == httpSpansScript {
+		} else if definition.Name == httpSpansScript || definition.Name == httpSampledSpansScript {
 			interval = config.HttpSpanCollectInterval
 		} else if definition.Name == jvmMetricsScript {
 			interval = config.JvmCollectInterval
-		} else if definition.Name == postgresqlSpansScript {
+		} else if definition.Name == postgresqlSpansScript || definition.Name == postgresqlSampledSpansScript {
 			interval = config.PostgresCollectInterval
-		} else if definition.Name == mysqlSpansScript {
+		} else if definition.Name == mysqlSpansScript || definition.Name == mysqlSampledSpansScript {
 			interval = config.MysqlCollectInterval
 		}
 		if interval == 0 {

--- a/internal/script/script_test.go
+++ b/internal/script/script_test.go
@@ -68,17 +68,17 @@ func getTemplatedScript(clusterName string, filter ...string) string {
 }
 
 func TestIsNewRelicScript(t *testing.T) {
-	assert.True(t, IsNewRelicScript("nri-script-cluster"))
+	assert.True(t, IsNewRelicScript("nri-script (cluster)"))
 	assert.False(t, IsNewRelicScript("not-nri-script"))
 }
 
 func TestIsScriptForCluster(t *testing.T) {
-	assert.True(t, IsScriptForCluster("nri-HTPT Metrics-test-cluster", "test-cluster"))
-	assert.False(t, IsScriptForCluster("nri-HTPT Metrics-test-cluster", "new-cluster"))
+	assert.True(t, IsScriptForCluster("nri-HTPT Metrics (test-cluster)", "test-cluster"))
+	assert.False(t, IsScriptForCluster("nri-HTPT Metrics (test-cluster)", "new-cluster"))
 }
 
 func TestGetScriptName(t *testing.T) {
-	assert.Equal(t, "nri-HTTP Metrics-test-cluster", getScriptName("HTTP Metrics", "test-cluster"))
+	assert.Equal(t, "nri-HTTP Metrics (test-cluster)", getScriptName("HTTP Metrics", "test-cluster"))
 }
 func TestGetIntervalCustomScript(t *testing.T) {
 	assert.Equal(t, int64(10), getInterval(&ScriptDefinition{
@@ -198,7 +198,7 @@ func TestGetActions(t *testing.T) {
 	actions = GetActions([]*ScriptDefinition{}, []*Script{
 		&Script{
 			ScriptDefinition: ScriptDefinition{
-				Name: "nri-script-another-cluster",
+				Name: "nri-script (another-cluster)",
 			},
 			ScriptId:   "06906e7e-c684-4858-9fa1-e0bf552b40a6",
 			ClusterIds: "91cb2c1d-e6fd-4fb9-9d2f-8358895bf484",
@@ -245,7 +245,7 @@ func TestGetActions(t *testing.T) {
 	assert.Equal(t, 0, len(actions.ToUpdate))
 	assert.Equal(t, 1, len(actions.ToCreate))
 
-	assert.Equal(t, "nri-HTTP Metrics-test-cluster", actions.ToCreate[0].Name)
+	assert.Equal(t, "nri-HTTP Metrics (test-cluster)", actions.ToCreate[0].Name)
 	assert.Equal(t, "This script sends HTTP metrics to New Relic's OTel endpoint.", actions.ToCreate[0].Description)
 	assert.Equal(t, int64(10), actions.ToCreate[0].FrequencyS)
 	assert.Equal(t, getTemplatedScript("test-cluster", "", "# New Relic integration filtering", ""), actions.ToCreate[0].Script)
@@ -263,7 +263,7 @@ func TestGetActions(t *testing.T) {
 	}, []*Script{
 		&Script{
 			ScriptDefinition: ScriptDefinition{
-				Name:        "nri-HTTP Metrics-test-cluster",
+				Name:        "nri-HTTP Metrics (test-cluster)",
 				Description: "This script sends HTTP metrics to New Relic's OTel endpoint.",
 				FrequencyS:  10,
 				Script:      getTemplatedScript("test-cluster", "", "# New Relic integration filtering", ""),
@@ -293,7 +293,7 @@ func TestGetActions(t *testing.T) {
 	}, []*Script{
 		&Script{
 			ScriptDefinition: ScriptDefinition{
-				Name:        "nri-HTTP Metrics-test-cluster",
+				Name:        "nri-HTTP Metrics (test-cluster)",
 				Description: "This script sends HTTP metrics to New Relic's OTel endpoint.",
 				FrequencyS:  10,
 				Script:      getTemplatedScript("test-cluster", "", "# New Relic integration filtering", ""),
@@ -325,7 +325,7 @@ func TestGetActions(t *testing.T) {
 	}, []*Script{
 		&Script{
 			ScriptDefinition: ScriptDefinition{
-				Name:        "nri-HTTP Metrics-test-cluster",
+				Name:        "nri-HTTP Metrics (test-cluster)",
 				Description: "This script sends HTTP metrics to New Relic's OTel endpoint.",
 				FrequencyS:  10,
 				Script:      getTemplatedScript("test-cluster", "", "# New Relic integration filtering", ""),
@@ -356,7 +356,7 @@ func TestGetActions(t *testing.T) {
 	}, []*Script{
 		&Script{
 			ScriptDefinition: ScriptDefinition{
-				Name:        "nri-HTTP Metrics-test-cluster",
+				Name:        "nri-HTTP Metrics (test-cluster)",
 				Description: "This script sends HTTP metrics to New Relic's OTel endpoint.",
 				FrequencyS:  10,
 				Script:      getTemplatedScript("test-cluster", "", "# New Relic integration filtering", ""),
@@ -412,7 +412,7 @@ func TestGetActions(t *testing.T) {
 		// outdated: different cluster name in script name
 		&Script{
 			ScriptDefinition: ScriptDefinition{
-				Name: "nri-HTTP Metrics-another-cluster",
+				Name: "nri-HTTP Metrics (another-cluster)",
 			},
 			ScriptId:   "06906e7e-c684-4858-9fa1-e0bf552b40a6",
 			ClusterIds: "91cb2c1d-e6fd-4fb9-9d2f-8358895bf484",
@@ -420,7 +420,7 @@ func TestGetActions(t *testing.T) {
 		// outdated: spans are now disabled
 		&Script{
 			ScriptDefinition: ScriptDefinition{
-				Name: "nri-HTTP Spans-test-cluster",
+				Name: "nri-HTTP Spans (test-cluster)",
 			},
 			ScriptId:   "cc6455ca-e12e-4a1d-b81c-ecc97a3d44cf",
 			ClusterIds: "91cb2c1d-e6fd-4fb9-9d2f-8358895bf484",
@@ -428,7 +428,7 @@ func TestGetActions(t *testing.T) {
 		// outdated: missing filter on mynamespace
 		&Script{
 			ScriptDefinition: ScriptDefinition{
-				Name:        "nri-JVM Metrics-test-cluster",
+				Name:        "nri-JVM Metrics (test-cluster)",
 				Description: "This script sends JVM metrics to New Relic's OTel endpoint.",
 				FrequencyS:  20,
 				Script:      testScript,
@@ -454,7 +454,7 @@ func TestGetActions(t *testing.T) {
 
 	assert.Equal(t, 2, len(actions.ToCreate))
 	var httpMetricsScript, customScript *Script
-	if actions.ToCreate[0].Name == "nri-HTTP Metrics-test-cluster" {
+	if actions.ToCreate[0].Name == "nri-HTTP Metrics (test-cluster)" {
 		httpMetricsScript = actions.ToCreate[0]
 		customScript = actions.ToCreate[1]
 	} else {
@@ -462,12 +462,12 @@ func TestGetActions(t *testing.T) {
 		customScript = actions.ToCreate[0]
 	}
 
-	assert.Equal(t, "nri-HTTP Metrics-test-cluster", httpMetricsScript.Name)
+	assert.Equal(t, "nri-HTTP Metrics (test-cluster)", httpMetricsScript.Name)
 	assert.Equal(t, "This script sends HTTP metrics to New Relic's OTel endpoint.", httpMetricsScript.Description)
 	assert.Equal(t, int64(20), httpMetricsScript.FrequencyS)
 	assert.Equal(t, getTemplatedScript("test-cluster", "", "# New Relic integration filtering", "df = df[not px.regex_match('mynamespace.*', df.namespace)]", ""), httpMetricsScript.Script)
 
-	assert.Equal(t, "nri-Custom Script-test-cluster", customScript.Name)
+	assert.Equal(t, "nri-Custom Script (test-cluster)", customScript.Name)
 	assert.Equal(t, "My custom script", customScript.Description)
 	assert.Equal(t, int64(10), customScript.FrequencyS)
 	assert.Equal(t, getTemplatedScript("test-cluster", ""), customScript.Script)


### PR DESCRIPTION
Currently we create script names with the format `nri-scriptName-clusterName`. This is a little unreadable when it shows up in the UI, so this change updates it to be `nri-scriptName (clusterName)`. 
The embedded view has a separate change which handles removing the `nri-` and properly moving the script to the presetScripts in the export script page.

Signed-off-by: Michelle Nguyen <michellenguyen@pixielabs.ai>