### PR TITLE
Don't enable non-default/non-user configured scripts

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -122,7 +122,7 @@ func main() {
 
 	for _, s := range actions.ToCreate {
 		log.Debugf("Creating script %s", s.Name)
-		err := client.AddDataRetentionScript(clusterId, s.Name, s.Description, s.FrequencyS, s.Script)
+		err := client.AddDataRetentionScript(clusterId, s.Name, s.Description, s.FrequencyS, s.Script, s.Disabled)
 		if err != nil {
 			errs = append(errs, err)
 		}

--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,5 @@ require (
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	google.golang.org/grpc v1.46.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	px.dev/pxapi v0.3.1 // indirect
+	px.dev/pxapi v0.4.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -329,3 +329,5 @@ px.dev/pxapi v0.3.0 h1:CCyXmE0KfMw8dY+l9+bZXzZTs3y2BFYRuJWtqtsJ6Bk=
 px.dev/pxapi v0.3.0/go.mod h1:I6MU0yzBHBXTR5nGE24JfnFlAv1hQDHR3oqWm02vEnw=
 px.dev/pxapi v0.3.1 h1:bY1haFi2+whRhWTvSrGFSaJ2SoR9cUHz386mTpUfi0M=
 px.dev/pxapi v0.3.1/go.mod h1:lSKIqQF2oljstbA7NgpP8ITFmHci3kFdS4VeIfb1XD4=
+px.dev/pxapi v0.4.1 h1:+9voAEpuov1yCieGhmt+SI2PaL4uojdbLRab6p51yPE=
+px.dev/pxapi v0.4.1/go.mod h1:lSKIqQF2oljstbA7NgpP8ITFmHci3kFdS4VeIfb1XD4=

--- a/internal/pixie/pixie.go
+++ b/internal/pixie/pixie.go
@@ -196,7 +196,7 @@ func (c *Client) getScriptDefinition(s *cloudpb.RetentionScript) (*script.Script
 	}, nil
 }
 
-func (c *Client) AddDataRetentionScript(clusterId string, scriptName string, description string, frequencyS int64, contents string) error {
+func (c *Client) AddDataRetentionScript(clusterId string, scriptName string, description string, frequencyS int64, contents string, disabled bool) error {
 	req := &cloudpb.CreateRetentionScriptRequest{
 		ScriptName:  scriptName,
 		Description: description,
@@ -204,6 +204,7 @@ func (c *Client) AddDataRetentionScript(clusterId string, scriptName string, des
 		Contents:    contents,
 		ClusterIDs:  []*uuidpb.UUID{utils.ProtoFromUUIDStrOrNil(clusterId)},
 		PluginId:    newRelicPluginId,
+		Disabled: disabled,
 	}
 	_, err := c.pluginClient.CreateRetentionScript(c.ctx, req)
 	return err

--- a/internal/script/script.go
+++ b/internal/script/script.go
@@ -43,7 +43,7 @@ type ScriptDefinition struct {
 	Script      string `yaml:"script"`
 	AddExcludes bool   `yaml:"addExcludes,omitempty"`
 	IsPreset    bool   `yaml:"-"`
-	Disabled    bool   `yaml:"disabled"`
+	Disabled    bool   `yaml:"-"`
 }
 
 type ScriptActions struct {

--- a/internal/script/script.go
+++ b/internal/script/script.go
@@ -43,6 +43,7 @@ type ScriptDefinition struct {
 	Script      string `yaml:"script"`
 	AddExcludes bool   `yaml:"addExcludes,omitempty"`
 	IsPreset    bool   `yaml:"-"`
+	Disabled    bool   `yaml:"disabled"`
 }
 
 type ScriptActions struct {
@@ -70,6 +71,7 @@ func GetActions(scriptDefinitions []*ScriptDefinition, currentScripts []*Script,
 				Description: definition.Description,
 				FrequencyS:  frequencyS,
 				Script:      templateScript(definition, config),
+				Disabled:    getDisabled(definition, config),
 			}
 		}
 	}
@@ -99,6 +101,26 @@ func GetActions(scriptDefinitions []*ScriptDefinition, currentScripts []*Script,
 
 func getScriptName(scriptName string, clusterName string) string {
 	return fmt.Sprintf("%s%s-%s", scriptPrefix, scriptName, clusterName)
+}
+
+func getDisabled(definition *ScriptDefinition, config ScriptConfig) bool {
+	if !definition.IsPreset {
+		return false
+	}
+	// By default, disable any preset scripts that do not belong to the core set of preset scripts.
+	switch definition.Name {
+	case httpMetricsScript:
+		return false
+	case httpSpansScript:
+		return false
+	case jvmMetricsScript:
+		return false
+	case postgresqlSpansScript:
+		return false
+	case mysqlSpansScript:
+		return false
+	}
+	return true
 }
 
 func getInterval(definition *ScriptDefinition, config ScriptConfig) int64 {


### PR DESCRIPTION
We are adding new preset scripts to the Pixie plugin. These scripts should not be enabled by default, as they are extras that a user may want to manually configure later.
This change updates the integration job such that a new script will be created for each of these non-default presets, but they aren't enabled. 