### PR TITLE
Allow overwriting license keys

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -55,7 +55,7 @@ func main() {
 		}
 		if config.LicenseKey != cfg.Exporter().LicenseKey() {
 			log.Info("New Relic plugin is configured with another license key... Overwriting")
-                	enablePlugin = true
+			enablePlugin = true
                 }
 	}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -54,6 +54,7 @@ func main() {
 			log.Fatal("the New Relic plugin is already installed with a different export URL")
 		}
 		if config.LicenseKey != cfg.Exporter().LicenseKey() {
+			log.Info("New Relic plugin is configured with another license key... Overwriting")
                 	enablePlugin = true
                 }
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -43,18 +43,22 @@ func main() {
 		log.WithError(err).Fatal("getting data retention plugins failed")
 	}
 
+	enablePlugin := true
 	if plugin.RetentionEnabled {
+		enablePlugin = false
 		config, err := client.GetNewRelicPluginConfig()
 		if err != nil {
 			log.WithError(err).Fatal("getting New Relic plugin config failed")
 		}
-		if config.LicenseKey != cfg.Exporter().LicenseKey() {
-			log.Fatal("the New Relic plugin is already installed with a different license key")
-		}
 		if config.ExportUrl != cfg.Exporter().Endpoint() {
 			log.Fatal("the New Relic plugin is already installed with a different export URL")
 		}
-	} else {
+		if config.LicenseKey != cfg.Exporter().LicenseKey() {
+                	enablePlugin = true
+                }
+	}
+
+	if enablePlugin {
 		log.Info("Enabling New Relic plugin")
 		err := client.EnableNewRelicPlugin(&pixie.NewRelicPluginConfig{
 			LicenseKey: cfg.Exporter().LicenseKey(),


### PR DESCRIPTION
Many users are unexpectedly running into an issue where they are unable to deploy the integration because of an existing license key. This change allows users to overwrite the old license key with their new desired key.
Signed-off-by: Michelle Nguyen <michellenguyen@pixielabs.ai>