### PR TITLE
If no custom excludes/limits are applied, use native preset scripts

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -105,6 +105,7 @@ func main() {
 		PostgresCollectInterval:   cfg.Worker().PostgresCollectInterval(),
 		ExcludePods:               cfg.Worker().ExcludePods(),
 		ExcludeNamespaces:         cfg.Worker().ExcludeNamespaces(),
+		IsCustomConfig:            cfg.Worker().IsCustomConfig(),
 	})
 
 	var errs []error
@@ -119,7 +120,15 @@ func main() {
 
 	for _, s := range actions.ToUpdate {
 		log.Debugf("Updating script %s", s.Name)
-		err := client.UpdateDataRetentionScript(clusterId, s.ScriptId, s.Name, s.Description, s.FrequencyS, s.Script)
+		if s.IsPreset {
+			err := client.UpdatePresetDataRetentionScript(s.ClusterIds, s.ScriptId, s.FrequencyS)
+			if err != nil {
+				errs = append(errs, err)
+			}
+			continue
+		}
+		
+		err := client.UpdateDataRetentionScript(s.ClusterIds, s.ScriptId, s.Name, s.Description, s.FrequencyS, s.Script)
 		if err != nil {
 			errs = append(errs, err)
 		}
@@ -127,7 +136,7 @@ func main() {
 
 	for _, s := range actions.ToCreate {
 		log.Debugf("Creating script %s", s.Name)
-		err := client.AddDataRetentionScript(clusterId, s.Name, s.Description, s.FrequencyS, s.Script)
+		err := client.AddDataRetentionScript(s.ClusterIds, s.Name, s.Description, s.FrequencyS, s.Script)
 		if err != nil {
 			errs = append(errs, err)
 		}

--- a/internal/pixie/pixie.go
+++ b/internal/pixie/pixie.go
@@ -134,7 +134,7 @@ func (c *Client) GetPresetScripts() ([]*script.ScriptDefinition, error) {
 	}
 	var l []*script.ScriptDefinition
 	for _, s := range resp.Scripts {
-		if s.IsPreset {
+		if s.IsPreset && s.PluginId == "new-relic" {
 			sd, err := c.getScriptDefinition(s)
 			if err != nil {
 				return nil, err
@@ -152,7 +152,7 @@ func (c *Client) GetClusterScripts(clusterId, clusterName string) ([]*script.Scr
 	}
 	var l []*script.Script
 	for _, s := range resp.Scripts {
-		if script.IsScriptForCluster(s.ScriptName, clusterName) || isScriptForClusterById(s.ScriptName, s.ClusterIDs, clusterId) {
+		if script.IsScriptForCluster(s.ScriptName, clusterName) || isScriptForClusterById(s.ScriptName, s.ClusterIDs, clusterId) || (s.IsPreset && s.PluginId == "new-relic") {
 			sd, err := c.getScriptDefinition(s)
 			if err != nil {
 				return nil, err

--- a/internal/pixie/pixie_test.go
+++ b/internal/pixie/pixie_test.go
@@ -9,13 +9,13 @@ import (
 )
 
 func TestGetScriptClusterIdsAsString(t *testing.T) {
-	assert.Equal(t, "", getClusterIdsAsString([]*uuidpb.UUID{}))
+	assert.Equal(t, []string{}, getClusterIdsAsString([]*uuidpb.UUID{}))
 
-	assert.Equal(t, "b8749d5b-3352-4a0c-92ef-4a1479464b74", getClusterIdsAsString([]*uuidpb.UUID{
+	assert.Equal(t, []string{"b8749d5b-3352-4a0c-92ef-4a1479464b74"}, getClusterIdsAsString([]*uuidpb.UUID{
 		utils.ProtoFromUUIDStrOrNil("b8749d5b-3352-4a0c-92ef-4a1479464b74"),
 	}))
 
-	assert.Equal(t, "b8749d5b-3352-4a0c-92ef-4a1479464b74,94fb8941-d353-43e0-b3e1-248f941c3af6", getClusterIdsAsString([]*uuidpb.UUID{
+	assert.Equal(t, []string{"b8749d5b-3352-4a0c-92ef-4a1479464b74","94fb8941-d353-43e0-b3e1-248f941c3af6"}, getClusterIdsAsString([]*uuidpb.UUID{
 		utils.ProtoFromUUIDStrOrNil("b8749d5b-3352-4a0c-92ef-4a1479464b74"),
 		utils.ProtoFromUUIDStrOrNil("94fb8941-d353-43e0-b3e1-248f941c3af6"),
 	}))


### PR DESCRIPTION
As we add and modify preset scripts in the plugin, we're seeing that auto-updating the plugin for integration users becomes complicated. This is because the integration users aren't actually using native preset scripts, but rather a custom script derived from the preset script.

In order to make this process simpler for the majority of integration users, any user who doesn't have custom excludes/limits should use the native preset script. For users with custom excludes/limits, the behavior will remain the same.