### PR TITLE
Let dependabot open upto 5 PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,14 +4,11 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
-    open-pull-requests-limit: 3
   - package-ecosystem: docker
     directory: "/"
     schedule:
       interval: daily
-    open-pull-requests-limit: 2
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: daily
-    open-pull-requests-limit: 2


### PR DESCRIPTION
Limiting dependabot just causes more work day over day.
A higher limit will help address all upgrades in a shorter
period of time.
