### PR TITLE
build(deps): bump aquasecurity/trivy-action from 0.9.2 to 0.10.0

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@0.9.2
+        uses: aquasecurity/trivy-action@0.10.0
         if: ${{ ! github.event.schedule }} # Do not run inline checks when running periodically
         with:
           scan-type: fs
@@ -37,7 +37,7 @@ jobs:
           severity: 'HIGH,CRITICAL'
 
       - name: Run Trivy vulnerability scanner sarif output
-        uses: aquasecurity/trivy-action@0.9.2
+        uses: aquasecurity/trivy-action@0.10.0
         if: ${{ github.event.schedule }} # Generate sarif when running periodically
         with:
           scan-type: fs


### PR DESCRIPTION
Manually recreating https://github.com/newrelic/newrelic-pixie-integration/pull/99 since Snyk doesn't work with dependabot PRs. 