### PR TITLE
build(deps): bump actions/github-script from 6.4.0 to 6.4.1

### DIFF
--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Test Default Branch
         id: default-branch
-        uses: actions/github-script@v6.4.0
+        uses: actions/github-script@v6.4.1
         with:
           script: |
             const data = await github.rest.repos.get(context.repo)


### PR DESCRIPTION
Recreating #98 since Snyk testing doesn't work with dependabot PRs. 
