### PR TITLE
Address issues found during GitHub action multi arch build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,11 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: newrelic/k8s-metadata-injection/.github/workflows/release-integration-reusable.yml@main
+    uses: ddelnano/k8s-metadata-injection/.github/workflows/release-integration-reusable.yml@ddelnano/allow-disabling-helm-chart-update
     with:
       repo_name: newrelic-pixie-integration
       artifact_path: bin/
+      disable_helm_chart_release: true
       docker_image_name: newrelic/newrelic-pixie-integration
       chart_directory: "REQUIRED_BUT_NOT_USED"
     secrets:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,7 @@
 ---
 on:
   release:
-    # Disable prereleased trigger since that requires opting into including the Helm chart
-    # in this repository.
-    # types: [prereleased, released]
-    types: [released]
+    types: [prereleased, released]
     tags:
       - 'v*'
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: ddelnano/k8s-metadata-injection/.github/workflows/release-integration-reusable.yml@ddelnano/allow-disabling-helm-chart-update
+    uses: newrelic/k8s-metadata-injection/.github/workflows/release-integration-reusable.yml@main
     with:
       repo_name: newrelic-pixie-integration
       artifact_path: bin/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     with:
       repo_name: newrelic-pixie-integration
       artifact_path: bin/
-      disable_helm_chart_release: true
+      enable_helm_chart_release: false
       docker_image_name: newrelic/newrelic-pixie-integration
       chart_directory: "REQUIRED_BUT_NOT_USED"
     secrets:

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ all: test build-container build
 build:
 	sh scripts/build.sh
 
+.PHONY: compile
+compile: build
+
 .PHONY: fmt
 fmt:
 	sh scripts/format.sh


### PR DESCRIPTION
Summary: Address issues found during GitHub action multi arch build

This addresses issues found from running the release action. It also relies on the following upstream workflow change (https://github.com/newrelic/k8s-metadata-injection/pull/488) to skip the helm chart version update. This repo's helm chart is managed in the [newrelic/helm-charts repo](https://github.com/newrelic/helm-charts/tree/549ee737e0461378c80d35ba0037aa0b839eacc4/charts/newrelic-pixie) and so the release logic fails when applied to this project. 

Relevant Issues: https://github.com/newrelic/helm-charts/issues/1152

Test Plan: The v2.1.8 was successfully built and the [prerelease](https://github.com/newrelic/newrelic-pixie-integration/actions/runs/6957486791) and [release](https://github.com/newrelic/newrelic-pixie-integration/actions/runs/6957513256) builds were successful.

<img width="1726" alt="Screenshot 2023-11-22 at 7 53 22 AM" src="https://github.com/newrelic/newrelic-pixie-integration/assets/5855593/ef3bd4e7-8b55-442e-8474-c58af57ba591">
