### PR TITLE
Update GitHub action release workflow reference

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: newrelic/k8s-metadata-injection/.github/workflows/release-integration-reusable.yml@main
+    uses: newrelic/k8s-agents-automation/.github/workflows/reusable-release-integration.yml@main
     with:
       repo_name: newrelic-pixie-integration
       artifact_path: bin/


### PR DESCRIPTION
Summary: Update GitHub action release workflow reference

The reusable GitHub action workflow we recently implemented (#144) was moved from the [newrelic/k8s-metadata-injection](https://github.com/newrelic/k8s-metadata-injection) repo to a automation focused repository ([newrelic/k8s-agent-automation](https://github.com/newrelic/k8s-agents-automation/)). This PR updates our reference so that our builds will continue to work once the workflow is removed from the metadata injection repo.

https://github.com/newrelic/newrelic-k8s-metrics-adapter/pull/254 shows this same change for another dependent repository for reference.