### PR TITLE
feat: Use the same security settings as other nri bundle components

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -3,7 +3,6 @@ name: Security Scan
 on:
   push:
     branches:
-      - master
       - main
       - renovate/**
   pull_request:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -3,52 +3,19 @@ name: Security Scan
 on:
   push:
     branches:
+      - master
       - main
+      - renovate/**
   pull_request:
   schedule:
-    - cron: "0 4 * * *"
+    - cron: "0 3 * * *"
 
 jobs:
-  security:
-    name: Snyk security scan
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: Run Snyk to check for vulnerabilities
-      uses: snyk/actions/golang@master
-      env:
-        SNYK_TOKEN: ${{ secrets.COREINT_SNYK_TOKEN }}
-      with:
-        args: --severity-threshold=high
   trivy:
-    name: Trivy security scan
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@0.11.2
-        if: ${{ ! github.event.schedule }} # Do not run inline checks when running periodically
-        with:
-          scan-type: fs
-          ignore-unfixed: true
-          exit-code: 1
-          severity: 'HIGH,CRITICAL'
-
-      - name: Run Trivy vulnerability scanner sarif output
-        uses: aquasecurity/trivy-action@0.11.2
-        if: ${{ github.event.schedule }} # Generate sarif when running periodically
-        with:
-          scan-type: fs
-          ignore-unfixed: true
-          severity: 'HIGH,CRITICAL'
-          format: 'template'
-          template: '@/contrib/sarif.tpl'
-          output: 'trivy-results.sarif'
-
-      - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
-        if: ${{ github.event.schedule }} # Upload sarif when running periodically
-        with:
-          sarif_file: 'trivy-results.sarif'
+    permissions:
+      contents: read # for actions/checkout to fetch code
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+    uses: newrelic/k8s-agents-automation/.github/workflows/reusable-security.yaml@main
+    secrets:
+      slack_channel: ${{ secrets.K8S_AGENTS_SLACK_CHANNEL }}
+      slack_token: ${{ secrets.K8S_AGENTS_SLACK_TOKEN }}


### PR DESCRIPTION
This automatically takes care of updating trivy packages when we merge the corresponding renovate PR inside
newrelic/k8s-agents-automation/.github/workflows/reusable-security.yaml@main

E.g.
https://github.com/newrelic/nri-kube-events/blob/main/.github/workflows/security.yml